### PR TITLE
Add GET /users/all endpoint to fetch paginated user data

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -31,6 +31,16 @@ class UserController {
     }
     res.status(200).json({ success: true, data: user });
   });
+
+  /**
+   * Get all users.
+   * @param {Object} req - Express request object.
+   * @param {Object} res - Express response object.
+   */
+  getAllUsers = asyncHandler(async (req, res) => {
+    const users = await userServices.getAllUsers();
+    res.status(200).json({ success: true, data: users });
+  });
 }
 
 export default new UserController();

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -33,13 +33,29 @@ class UserController {
   });
 
   /**
-   * Get all users.
-   * @param {Object} req - Express request object.
-   * @param {Object} res - Express response object.
+   * Get paginated users.
+   * @param {Object} req
+   * @param {Object} res
    */
   getAllUsers = asyncHandler(async (req, res) => {
-    const users = await userServices.getAllUsers();
-    res.status(200).json({ success: true, data: users });
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 50;
+
+    const { data, total } = await userServices.getAllUsersPaginated(
+      page,
+      limit
+    );
+
+    res.status(200).json({
+      success: true,
+      data,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
   });
 }
 

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -38,22 +38,60 @@ class UserController {
    * @param {Object} res
    */
   getAllUsers = asyncHandler(async (req, res) => {
-    const page = parseInt(req.query.page) || 1;
-    const limit = parseInt(req.query.limit) || 50;
+    const MAX_LIMIT = 5;
+
+    // Parse values safely
+    const rawPage = req.query.page;
+    const rawLimit = req.query.limit;
+
+    let page = parseInt(rawPage);
+    let limit = parseInt(rawLimit);
+
+    // Page validation (before using it)
+    if (!page || isNaN(page) || page <= 0) {
+      return res.status(400).json({
+        success: false,
+        message: `Page must be a positive number starting from 1.`,
+      });
+    }
+
+    // Limit validation
+    if (!limit || isNaN(limit) || limit <= 0) {
+      return res.status(400).json({
+        success: false,
+        message: `Limit must be a positive number between 1 and ${MAX_LIMIT}.`,
+      });
+    }
+
+    let responseMessage;
+    if (limit > MAX_LIMIT) {
+      limit = MAX_LIMIT;
+      res.set('X-Limit-Adjusted', true);
+      responseMessage = `Limit capped to ${MAX_LIMIT}. You requested ${rawLimit}.`;
+    }
 
     const { data, total } = await userServices.getAllUsersPaginated(
       page,
       limit
     );
+    const totalPages = Math.ceil(total / limit);
+
+    if (page > totalPages && total > 0) {
+      return res.status(400).json({
+        success: false,
+        message: `Only ${totalPages} page(s) available. You requested page ${page}.`,
+      });
+    }
 
     res.status(200).json({
       success: true,
+       ...(responseMessage && { message: responseMessage }),
       data,
       pagination: {
         total,
         page,
         limit,
-        totalPages: Math.ceil(total / limit),
+        totalPages,
       },
     });
   });

--- a/src/dao/user.dao.js
+++ b/src/dao/user.dao.js
@@ -91,6 +91,18 @@ class UserDAO {
     const user = await User.aggregate([{ $sample: { size: 1 } }]);
     return user.length > 0 ? user[0] : null;
   }
+
+  /**
+   * Get all users with optional field selection.
+   * @param {string} selectFields - Space-separated list of fields to return.
+   * @returns {Promise<Array>} - Array of user documents.
+   */
+  async findAllUsers(selectFields = '') {
+    if (selectFields) {
+      return await User.find().select(selectFields);
+    }
+    return await User.find();
+  }
 }
 
 export default new UserDAO();

--- a/src/dao/user.dao.js
+++ b/src/dao/user.dao.js
@@ -97,11 +97,19 @@ class UserDAO {
    * @param {string} selectFields - Space-separated list of fields to return.
    * @returns {Promise<Array>} - Array of user documents.
    */
-  async findAllUsers(selectFields = '') {
-    if (selectFields) {
-      return await User.find().select(selectFields);
-    }
-    return await User.find();
+  /**
+   * Get paginated list of users.
+   * @param {number} page - Page number
+   * @param {number} limit - Number of users per page
+   * @returns {Promise<Object>} - { data: [], total }
+   */
+  async getAllUsersPaginated(page = 1, limit = 50) {
+    const skip = (page - 1) * limit;
+    const [data, total] = await Promise.all([
+      User.find().skip(skip).limit(limit),
+      User.countDocuments(),
+    ]);
+    return { data, total };
   }
 }
 

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -13,4 +13,7 @@ router
 
 router.route('/getrandomuser').get(userController.getRandomUser);
 
+router.route('/all').get(userController.getAllUsers);
+
+
 export default router;

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -257,15 +257,15 @@ class UserService {
   }
 
   /**
-   * Get all users (safe fields only).
-   * @returns {Promise<Array>} - List of user objects
+   * Get all users with pagination.
+   * @param {number} page
+   * @param {number} limit
+   * @returns {Promise<Object>} - Paginated users with total count
    */
-  async getAllUsers() {
-  const users = await userDAO.findAllUsers(
-    'username name email avatar role createdAt'
-  );
-  return users;
-}
+  async getAllUsersPaginated(page, limit) {
+    return await userDAO.getAllUsersPaginated(page, limit);
+  }
+
 }
 
 export default new UserService();

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -255,6 +255,17 @@ class UserService {
     const user = await userDAO.getRandomUser();
     return user;
   }
+
+  /**
+   * Get all users (safe fields only).
+   * @returns {Promise<Array>} - List of user objects
+   */
+  async getAllUsers() {
+  const users = await userDAO.findAllUsers(
+    'username name email avatar role createdAt'
+  );
+  return users;
+}
 }
 
 export default new UserService();


### PR DESCRIPTION
1. Added a new endpoint GET /users/all to fetch paginated users.
2. Supports page and limit query parameters to avoid loading all users at once and improve performance.
3. Tested locally with dummy data.
4. Ready for review and merge.
![Screenshot 2025-07-03 172838](https://github.com/user-attachments/assets/24d91f94-ec51-4999-8c4d-4ff240303394)
